### PR TITLE
Coderabbit attempt

### DIFF
--- a/app/Exceptions/OwnOfficeReservationException.php
+++ b/app/Exceptions/OwnOfficeReservationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class OwnOfficeReservationException extends Exception
+{
+    public function render()
+    {
+        return response()->json([
+            'errors' => [
+                'office_id' => 'You cannot make a reservation on your own office'
+            ]
+        ], 422);
+    }
+}

--- a/app/Http/Controllers/UserReservationController.php
+++ b/app/Http/Controllers/UserReservationController.php
@@ -2,20 +2,24 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\OwnOfficeReservationException;
+use App\Http\Requests\StoreReservationRequest;
 use App\Http\Resources\ReservationResource;
 use App\Models\Office;
 use App\Models\Reservation;
 use App\Notifications\NewHostReservation;
 use App\Notifications\NewUserReservation;
-use Carbon\Carbon;
+use App\Services\ReservationService;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 class UserReservationController extends Controller
 {
+    // CodeRabbit forgot this
+    use AuthorizesRequests;
+
     public function index()
     {
 
@@ -25,54 +29,41 @@ class UserReservationController extends Controller
     {
     }
 
-    public function store(Request $request): ReservationResource
+    public function store(StoreReservationRequest $request, ReservationService $reservationService): ReservationResource
     {
-        abort_unless(auth()->user()->tokenCan('reservations.make'), 403);
+        $this->authorize('create', Reservation::class);
 
-        $data = $request->validate([
-            'office_id' => ['required', 'integer', 'exists:offices,id'],
-            'start_date' => ['required', 'date', 'after:today'],
-            'end_date' => ['required', 'date', 'after:start_date'],
-        ]);
+        $data = $request->validated();
+        $user = auth()->user();
 
         $office = Office::findOrFail($data['office_id']);
 
+        // Office-related validations
+        $this->validateOffice($office);
+
+        $reservation = $reservationService->createReservation($user, $office, $data);
+
+        // Send Notifications
+        dispatch(function () use ($user, $reservation) {
+            Notification::send($user, new NewUserReservation($reservation));
+        });
+
+        dispatch(function () use ($office, $reservation) {
+            Notification::send($office->user, new NewHostReservation($reservation));
+        });
+
+        return new ReservationResource($reservation->load('office'));
+    }
+
+    private function validateOffice(Office $office)
+    {
         if ($office->user_id === auth()->id()) {
-            throw ValidationException::withMessages(['office_id' => 'You cannot make a reservation on your own office']);
+            throw new OwnOfficeReservationException();
         }
 
         if ($office->hidden || $office->approval_status !== 'approved') {
             throw ValidationException::withMessages(['office_id' => 'You cannot make a reservation on a hidden or unapproved office']);
         }
-
-        $reservation = Cache::lock('reservations_office_' . $office->id, 10)->block(3, function () use ($data, $office) {
-            $numberOfDays = round(Carbon::parse($data['end_date'])->endOfDay()->diffInDays(Carbon::parse($data['start_date'])->startOfDay()) + 1) * -1;
-
-            if ($office->reservations()->activeBetween($data['start_date'], $data['end_date'])->exists()) {
-                throw ValidationException::withMessages(['office_id' => 'You cannot make a reservation during this time']);
-            }
-
-            $price = $numberOfDays * $office->price_per_day;
-
-            if ($numberOfDays >= 28 && $office->monthly_discount) {
-                $price = $price * ((100 - $office->monthly_discount) / 100);
-            }
-
-            return Reservation::create([
-                'user_id' => auth()->id(),
-                'office_id' => $office->id,
-                'start_date' => $data['start_date'],
-                'end_date' => $data['end_date'],
-                'status' => 'active',
-                'price' => $price,
-                'wifi_password' => Str::random(),
-            ]);
-        });
-
-        Notification::send(auth()->user(), new NewUserReservation($reservation));
-        Notification::send($office->user, new NewHostReservation($reservation));
-
-        return new ReservationResource($reservation->load('office'));
     }
 
     public function show($id)

--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReservationRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return auth()->user()->tokenCan('reservations.make');
+    }
+
+    public function rules()
+    {
+        return [
+            'office_id' => ['required', 'integer', 'exists:offices,id'],
+            'start_date' => ['required', 'date', 'after:today'],
+            'end_date' => ['required', 'date', 'after:start_date'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'office_id.required' => 'Office is required',
+            // Add other custom messages as needed
+        ];
+    }
+}

--- a/app/Policies/ReservationPolicy.php
+++ b/app/Policies/ReservationPolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ReservationPolicy
+{
+    use HandlesAuthorization;
+
+    public function create(User $user)
+    {
+        return $user->tokenCan('reservations.make');
+    }
+}

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Office;
+use App\Models\Reservation;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class ReservationService
+{
+    public function createReservation($user, Office $office, array $data): Reservation
+    {
+        $lock = Cache::lock('reservations_office_' . $office->id, 10);
+
+        if ($lock->get()) {
+            try {
+                $numberOfDays = Carbon::parse($data['start_date'])->diffInDays(Carbon::parse($data['end_date']));
+
+                if ($office->reservations()->activeBetween($data['start_date'], $data['end_date'])->exists()) {
+                    throw ValidationException::withMessages(['office_id' => 'You cannot make a reservation during this time']);
+                }
+
+                $price = $this->calculatePrice($office, $numberOfDays);
+
+                return Reservation::create([
+                    'user_id' => $user->id,
+                    'office_id' => $office->id,
+                    'start_date' => $data['start_date'],
+                    'end_date' => $data['end_date'],
+                    'status' => 'active',
+                    'price' => $price,
+                    'wifi_password' => Str::random(),
+                ]);
+            } finally {
+                $lock->release();
+            }
+        } else {
+            throw ValidationException::withMessages(['office_id' => 'Unable to acquire lock. Please try again later.']);
+        }
+    }
+
+    private function calculatePrice(Office $office, int $numberOfDays): float
+    {
+        $price = $numberOfDays * $office->price_per_day;
+
+        if ($numberOfDays >= 28 && $office->monthly_discount) {
+            $price *= (100 - $office->monthly_discount) / 100;
+        }
+
+        return $price;
+    }
+}


### PR DESCRIPTION

1. **Use Form Requests for Validation**

   Instead of validating the request data directly in the controller, you can create a dedicated Form Request class. This keeps your controller clean and isolates the validation logic.

2. **Extract Business Logic to a Service Class**

   Move complex business logic from the controller to a dedicated service class. This promotes single responsibility and makes your code more testable.

3. **Simplify Date Calculations**

   You can simplify the calculation of `$numberOfDays`:
   
   There's no need to use `startOfDay()` and `endOfDay()` unless you're considering time components.

4. **Ensure Positive Number of Days**

   Remove the multiplication by `-1` to ensure `$numberOfDays` is positive:

5. **Use Policies for Authorization**

   Instead of using `abort_unless`, consider using Laravel's authorization policies for cleaner code:

6. **Asynchronous Notifications**

   Dispatch notifications using jobs to handle them asynchronously, improving the response time of your API:

7. **Consistent Naming and File Structure**

   Ensure that your controller class name matches the file name for autoloading to work correctly. If your class is `UserReservationController`, the file should be `UserReservationController.php`.

8. **Remove Empty Methods**

   If methods like `index`, `create`, `edit`, `update`, and `destroy` are not implemented, consider removing them until they are needed to keep the controller clean.

9. **Customize Exception Messages**

   Create custom exceptions for specific scenarios to provide clearer error messages and to handle them appropriately.

10. **Refactor Price Calculation Logic**

    Move price calculation to a dedicated method or service to isolate this logic:

11. **Handle Cache Lock Failures**

    Consider handling scenarios where acquiring the lock fails or times out to provide a better user experience.

12. **Avoid Querying Inside Locks**

    Minimize database queries inside the cache lock to reduce lock time. For example, perform checks before acquiring the lock when possible.
